### PR TITLE
Added src folder to path to find components.py and callbacks.py modules

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,8 @@
 from dash import Dash, html, dcc
 import dash_bootstrap_components as dbc
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'src')))
 from components import cards, balance_plot, contact_plot, loan_plot
 app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server


### PR DESCRIPTION
I was getting a deployment error because it can't find components module when running app.py for some reason. I added src to path to see if this solves the problem